### PR TITLE
fix: `rebuild` and `validate` GitHub actions

### DIFF
--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -30,14 +30,21 @@ jobs:
         run: uv run src/main.py
 
       - name: Commit changes
+        id: commit
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
           git add data/funding_data{.json,.csv}
-          git commit -m "chore: rebuild \`funding\` data"
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "chore: rebuild \`funding\` data"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Push changes and create PR
-        if: success()
+        if: steps.commit.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "chore: rebuild `funding` data"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -28,6 +30,7 @@ jobs:
       - name: Find modified CSV files
         id: find_csv
         run: |
+          git fetch origin ${{ github.base_ref }}
           FILES=$(git diff --name-only origin/${{ github.base_ref }} | grep '\.csv$' || echo "")
           echo "Modified CSV files:"
           echo "$FILES"


### PR DESCRIPTION
This PR closes https://github.com/opensource-observer/oso/issues/3755 by fetching the full history and adding some logic to check if there are no changes on the commit.